### PR TITLE
fixes issue #31

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,5 @@ install:
 
 script:
   nosetests -v --with-coverage --cover-package=l2l/
+after_success:
+  - coveralls


### PR DESCRIPTION
The command `after_success: coveralls` should invoke `coveralls.io`to display the coverage. Fixes #31  