### PR TITLE
Renaming of parameters 

### DIFF
--- a/bin/l2l-fun-ga.py
+++ b/bin/l2l-fun-ga.py
@@ -28,10 +28,11 @@ def main():
     optimizee = FunctionGeneratorOptimizee(traj, benchmark_function, seed=optimizee_seed)
 
     ## Outerloop optimizer initialization
-    parameters = GeneticAlgorithmParameters(seed=0, popsize=50, CXPB=0.5,
-                                            MUTPB=0.3, NGEN=100, indpb=0.02,
-                                            tournsize=15, matepar=0.5,
-                                            mutpar=1
+    parameters = GeneticAlgorithmParameters(seed=0, pop_size=50, cx_prob=0.5,
+                                            mut_prob=0.3, n_iteration=100,
+                                            ind_prob=0.02,
+                                            tourn_size=15, mate_par=0.5,
+                                            mut_par=1
                                             )
 
     optimizer = GeneticAlgorithmOptimizer(traj, optimizee_create_individual=optimizee.create_individual,

--- a/l2l/tests/test_ga_optimizer.py
+++ b/l2l/tests/test_ga_optimizer.py
@@ -8,10 +8,10 @@ class GAOptimizerTestCase(OptimizerTestCase):
 
     def test_setup(self):
 
-        optimizer_parameters = GeneticAlgorithmParameters(seed=0, popsize=1, CXPB=0.5,
-                                                          MUTPB=0.3, NGEN=1, indpb=0.02,
-                                                          tournsize=1, matepar=0.5,
-                                                          mutpar=1
+        optimizer_parameters = GeneticAlgorithmParameters(seed=0, pop_size=1, cx_prob=0.5,
+                                                          mut_prob=0.3, n_iteration=1, ind_prob=0.02,
+                                                          tourn_size=1, mate_par=0.5,
+                                                          mut_par=1
                                                           )
 
         optimizer = GeneticAlgorithmOptimizer(self.trajectory, optimizee_create_individual=self.optimizee.create_individual,


### PR DESCRIPTION
In the genetic algorithm optimizer the parameter names did not follow the standard naming notation. This is a quick PR to homogenize the names. See issue #3 

With the latest python versions `namedtuples` are much more comfortable to deal with, so I would suggest to leave the namedtuple approach as it is. 