### PR TITLE
enabled to turn on debug variable for verbose output

### DIFF
--- a/l2l/utils/JUBE_runner.py
+++ b/l2l/utils/JUBE_runner.py
@@ -62,7 +62,7 @@ class JUBERunner():
             os.makedirs(self.work_paths[dir], exist_ok=True)
 
         self.zeepath = os.path.join(self.path, "optimizee.bin")
-        self.debug_stderr = False
+        self.debug_stderr = self.trajectory.debug
 
 
     def write_pop_for_jube(self, trajectory, generation):

--- a/l2l/utils/experiment.py
+++ b/l2l/utils/experiment.py
@@ -36,6 +36,8 @@ class Experiment(object):
             - jube_parameter: dict, User specified parameter for jube.
                 See notes section for default jube parameter
             - multiprocessing, bool, enable multiprocessing, Default: False
+            - debug, bool, enable verbose mode to print out errors appearing
+                in the optimizee, Default: False
         :return traj, trajectory object
         :return all_jube_params, dict, a dictionary with all parameters for jube
             given by the user and default ones
@@ -84,7 +86,8 @@ class Experiment(object):
             add_time=True,
             automatic_storing=True,
             log_stdout=kwargs.get('log_stdout', False),  # Sends stdout to logs
-            multiprocessing=kwargs.get('multiprocessing', True)
+            multiprocessing=kwargs.get('multiprocessing', True),
+            debug = kwargs.get('debug', False)
         )
 
         create_shared_logger_data(


### PR DESCRIPTION
A small modification to give a parameter `debug=True` to `prepare_experiment` in order to enable debug output. The debug output passes errors, which appear in the optimizee, to the standard output and can be seen while the simulation is ongoing. 

_Example_: in the run script do:

```python
    experiment = Experiment(root_dir_path='~/home/user/L2L/results')
    jube_params = {}
    traj, all_jube_params = experiment.prepare_experiment(name='L2L',
                                                          log_stdout=True,
                                                          jube_parameter=jube_params,
                                                          debug=True) # Enable debug output
```