### PR TITLE
removed unnecessaray entry from ready files list

### DIFF
--- a/l2l/utils/JUBE_runner.py
+++ b/l2l/utils/JUBE_runner.py
@@ -217,7 +217,6 @@ class JUBERunner():
         for ind in self.trajectory.individuals[generation]:
             ready_files.append(path_ready + str(ind.ind_idx))
 
-        ready_files.append(path_ready + str(generation))
 
         # Call the main function from JUBE
         logger.info("JUBE running generation: " + str(self.generation))


### PR DESCRIPTION
The addition of another entry of the form "ready_{gen}_{gen}" is redundant and leads to errors as the file is never specifically created. It has been working most of the time because it has the same name as the "ready_{gen}_{ind}" file. However, it breaks when there are more generations than individuals per generation.